### PR TITLE
Fixes to have example up and running

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ use the following commands to clone and build the modified Keycloak version:
     git clone git@github.com:pedroigor/keycloak.git
     cd keycloak
     git checkout -b KEYCLOAK-2615    
-    mvn -DskipTests clean install
+    mvn -DskipTests -Pdistribution clean install
     
 Now you can clone and this project using the following command:
 

--- a/distribution/wildfly/server-feature-pack/pom.xml
+++ b/distribution/wildfly/server-feature-pack/pom.xml
@@ -43,7 +43,7 @@
         <!-- Keycloak AuthZ -->
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-authz-server-services-core</artifactId>
+            <artifactId>keycloak-authz-server-services-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
- The module "keycloak-authz-server-services-core" doesn't seem to exist, so I had an issue when trying to build the project with maven. Changing to "keycloak-authz-server-services-common" seemed to fix it.

- Without the "-Pdistribution" during build of Keycloak, the changes in index.ftl on keycloak side were not applied. So admin console wasn't able to find the custom JS scripts from keycloak-authz theme (I am not 100%sure, but I think that it was adding -Pdistribution which fixed this issue)